### PR TITLE
Modify cost of nan/inf edges

### DIFF
--- a/lapsolver/tests/test_dense.py
+++ b/lapsolver/tests/test_dense.py
@@ -63,4 +63,26 @@ def test_solve_inf():
     r = lap.solve_dense(costs)
     expected = np.array([[0, 1, 2], [0, 2, 1]])
     np.testing.assert_allclose(r, expected)
-    
+
+def test_missing_edge_negative():
+    costs = np.array([[-1000, -1], [-1, np.nan]])
+    r = lap.solve_dense(costs)
+    # The optimal solution is (0, 1), (1, 0) with cost -1 + -1.
+    # If the implementation does not use a large enough constant, it may choose
+    # (0, 0), (1, 1) with cost -1000 + L.
+    expected = np.array([[0, 1], [1, 0]])
+    np.testing.assert_allclose(r, expected)
+
+def test_missing_edge_positive():
+    costs = np.array([
+        [np.nan, 1000, np.nan],
+        [np.nan, 1, 1000],
+        [1000, np.nan, 1],
+    ])
+    costs_copy = costs.copy()
+    r = lap.solve_dense(costs)
+    # The optimal solution is (0, 1), (1, 2), (2, 0) with cost 1000 + 1000 + 1000.
+    # If the implementation does not use a large enough constant, it may choose
+    # (0, 0), (1, 1), (2, 2) with cost (L + 1 + 1) instead.
+    expected = np.array([[0, 1, 2], [1, 2, 0]])
+    np.testing.assert_allclose(r, expected)

--- a/src/dense_wrap.hpp
+++ b/src/dense_wrap.hpp
@@ -30,7 +30,7 @@ py::tuple solve_dense_wrap(py::array_t<T, ExtraFlags> input1) {
     for(int i = 0; i < nrows*ncols; ++i) {
         if (std::isfinite((double)data[i])) {
             any_finite = true;
-            LARGE_COST = std::max<T>(LARGE_COST, data[i]);
+            LARGE_COST = std::max<T>(LARGE_COST, std::abs<T>(data[i]));
         }
     }
          
@@ -38,8 +38,9 @@ py::tuple solve_dense_wrap(py::array_t<T, ExtraFlags> input1) {
         return py::make_tuple(py::array(), py::array());
     }
 
-    LARGE_COST = 2*LARGE_COST + 1;
+    const int r = std::min<int>(nrows, ncols);
     const int n = std::max<int>(nrows, ncols);
+    LARGE_COST = 2 * r * LARGE_COST + 1;
     std::vector<std::vector<T>> costs(n, std::vector<T>(n, LARGE_COST));
 
     for (int i = 0; i < nrows; i++)
@@ -62,11 +63,11 @@ py::tuple solve_dense_wrap(py::array_t<T, ExtraFlags> input1) {
     for (int i = 0; i < nrows; i++)
     {
         int mate = Lmate[i];
-		if (Lmate[i] < ncols && costs[i][mate] != LARGE_COST)
-		{
+        if (Lmate[i] < ncols && costs[i][mate] != LARGE_COST)
+        {
             rowids.push_back(i);
             colids.push_back(mate);
-		}
+        }
     }
 
     return py::make_tuple(py::array(rowids.size(), rowids.data()), py::array(colids.size(), colids.data()));


### PR DESCRIPTION
I found that lapsolver gives the wrong result in some cases. This can be fixed by increasing the constant from 2 c + 1 to 2 r c + 1 where c is the maximum absolute value and r is the size of the smaller set.