### PR TITLE
Bump submodule for latest release of pybind11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pybind11"]
 	path = pybind11
 	url = https://github.com/pybind/pybind11.git
-	branch = v2.2
+	branch = v2.10.1


### PR DESCRIPTION
I think this fixes building on Python 3.11.  Fixes #18.

- - - -

I'm not used to working with `git submodules`, so I hope I've done this right.  The idea was to bump the including (submodule) for `pybind11` to the latest release.

After this change, `pip install .` works for me on Python 3.11.  I have not extensively tested.